### PR TITLE
fix: can't get the CSRF token

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ let countFail = 0;
   let originPostId = await getFirstPostId();
   stopIntervalId = setInterval(async () => {
     console.log(`${new Date()}: '我還活著'`);
-    const headerInfo = await getToken(process.env.TARGET_URL);
+    const headerInfo = await getToken();
     const houseListURL = `https://rent.591.com.tw/home/search/rsList?${process.env.TARGET_URL.split('?')[1]}`;
     const csrfToken = headerInfo[0];
     const cookie = headerInfo[1];

--- a/lib/getFirstPostId.js
+++ b/lib/getFirstPostId.js
@@ -3,7 +3,7 @@ const getToken = require('./getToken');
 require('dotenv').config();
 
 module.exports = async () => {
-  const headerInfo = await getToken(process.env.TARGET_URL);
+  const headerInfo = await getToken();
   const houseListURL = `https://rent.591.com.tw/home/search/rsList?${process.env.TARGET_URL.split('?')[1]}`;
   const csrfToken = headerInfo[0];
   const cookie = headerInfo[1];

--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -1,9 +1,9 @@
 const { getRequest } = require('./request');
 
-module.exports = async (targetUrl) => {
+module.exports = async () => {
   const regExp = new RegExp('<meta name="csrf-token" content="([A-Za-z0-9]*)">', 'gi');
   const response = await getRequest({
-    url: targetUrl,
+    url: 'https://rent.591.com.tw',
     json: true,
   });
   const csrfToken = regExp.exec(response.body)[1];


### PR DESCRIPTION
Root cause:
Use the search API can't get CSRF.
It will raise the below error:
```
yarn run v1.22.10
$ node app.js
/Users/zephyr/Documents/Coding/dummy/rentHouse/lib/getToken.js:9
  const csrfToken = regExp.exec(response.body)[1];
                                              ^

TypeError: Cannot read properties of null (reading '1')
    at module.exports (/Users/zephyr/Documents/Coding/dummy/rentHouse/lib/getToken.js:9:47)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async module.exports (/Users/zephyr/Documents/Coding/dummy/rentHouse/lib/getFirstPostId.js:6:22)
    at async /Users/zephyr/Documents/Coding/dummy/rentHouse/app.js:11:22

Node.js v17.5.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Solution: change the fetching site to the 591 index URL.